### PR TITLE
Add snyk orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
-version: 2
+version: 2.1
+
+orbs:
+  change-api: financial-times/change-api@0.24.0
+  ft-snyk-orb: financial-times/ft-snyk-orb@0
 
 references:
 
@@ -68,10 +72,45 @@ workflows:
           filters:
             tags:
               only: /.*/
+
+      #Scan package.json for vulnerable dependencies while developing
+      - ft-snyk-orb/scan-js-packages:
+          context: rel-eng-creds
+          requires:
+          - install
+          filters: /.*/
+
       - release:
           requires:
             - install
           filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
+
+      #Scan and monitor vulnerabilities once in production
+      - ft-snyk-orb/scan-and-monitor-js-packages:
+          name: snyk-scan-and-monitor
+          context: rel-eng-creds
+          requires:
+            - release
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
+
+      - change-api/release-log:
+          name: 'change_log_prod'
+          context: 'rel-eng-creds'
+          systemCode: 'serverless-plugin-about'
+          environment: 'prod'
+          slackChannels: 'rel-eng-changes'
+          requires:
+            - release
+          filters:
+            <<: *only_version_tags
             branches:
               ignore: /.*/
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
   container_config: &container_config
     working_directory: ~/project/serverless-plugin-about
     docker:
-      - image: circleci/node:6.10.3
+      - image: circleci/node:10
 
   workspace_root: &workspace_root
     ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,6 @@ workflows:
           requires:
             - release
           filters:
-            <<: *only_version_tags
             branches:
               ignore: /.*/
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,10 @@ workflows:
       - ft-snyk-orb/scan-js-packages:
           context: rel-eng-creds
           requires:
-          - install
-          filters: /.*/
+            - install
+          filters:
+            tags:
+              only: /.*/
 
       - release:
           requires:


### PR DESCRIPTION
## What

Added change-api and snyk orbs

## Why

To ensure snyk vulnerability checking runs during commits and releases and that change logging runs during releases.